### PR TITLE
Cleaner implementation

### DIFF
--- a/arches_orm/_internals/relations.py
+++ b/arches_orm/_internals/relations.py
@@ -1,4 +1,6 @@
 import collections
+import uuid
+from typing import Protocol
 
 
 class RelationList(collections.UserList):
@@ -20,3 +22,7 @@ class RelationList(collections.UserList):
         item._cross_record = datum
         super().append(item)
         return item
+
+class WKRI(Protocol):
+    graph_id: uuid.UUID
+    _cross_record: dict | None = None

--- a/arches_orm/_internals/relations.py
+++ b/arches_orm/_internals/relations.py
@@ -1,27 +1,6 @@
-import collections
 import uuid
 from typing import Protocol
 
-
-class RelationList(collections.UserList):
-    """Manages a list of related resources on a well-known resource."""
-
-    def __init__(self, related_to, key, nodeid, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.related_to = related_to
-        self.key = key
-        self.nodeid = nodeid
-
-    def append(self, item, tile):
-        """Add a well-known resource to the list."""
-        datum = {}
-        datum["wkriFrom"] = self.related_to
-        datum["wkriFromKey"] = self.key
-        datum["wkriFromNodeid"] = self.nodeid
-        datum["wkriFromTile"] = self.tile
-        item._cross_record = datum
-        super().append(item)
-        return item
 
 class WKRI(Protocol):
     graph_id: uuid.UUID

--- a/arches_orm/_internals/translation.py
+++ b/arches_orm/_internals/translation.py
@@ -4,17 +4,18 @@ from arches.app.models.models import ResourceXResource, Node, NodeGroup
 from arches.app.models.tile import Tile as TileProxyModel
 from arches.app.models.system_settings import settings as system_settings
 from collections import UserList
-from .relations import RelationList
 from .view_models import get_view_model_for_datatype
 
 
 LOAD_FULL_NODE_OBJECTS = True
 LOAD_ALL_NODES = True
 
+
 class PseudoNodeList(UserList):
     def __init__(self, nodegroup):
         super().__init__()
         self.nodegroup = nodegroup
+
 
 class PseudoNode:
     _value_loaded = False
@@ -40,7 +41,9 @@ class PseudoNode:
             tile_value = self._value.as_tile_data()
         except AttributeError:
             tile_value = self._value
-        self.tile.data[str(self.node.nodeid)] = tile_value # TODO: ensure this works for any value
+        self.tile.data[
+            str(self.node.nodeid)
+        ] = tile_value  # TODO: ensure this works for any value
         return self.tile
 
     def _update_value(self):
@@ -48,9 +51,7 @@ class PseudoNode:
             if not self.node:
                 raise RuntimeError("Empty tile")
             self.tile = TileProxyModel(
-                nodegroup_id=self.node.nodegroup_id,
-                tileid=None,
-                data={}
+                nodegroup_id=self.node.nodegroup_id, tileid=None, data={}
             )
         if not self._value_loaded:
             if self.tile.data is not None and str(self.node.nodeid) in self.tile.data:
@@ -63,7 +64,7 @@ class PseudoNode:
                     self.node,
                     value=data,
                     parent=self._parent,
-                    related_prefetch=self._related_prefetch
+                    related_prefetch=self._related_prefetch,
                 )
             except KeyError:
                 self._value = self.tile.data[str(self.node.nodeid)]
@@ -83,7 +84,9 @@ class PseudoNode:
 class SemanticTile(dict):
     __tile: TileProxyModel
 
-    def __init__(self, tile: TileProxyModel | None=None, nodegroup: NodeGroup | None=None):
+    def __init__(
+        self, tile: TileProxyModel | None = None, nodegroup: NodeGroup | None = None
+    ):
         if tile is None:
             if nodegroup is None:
                 raise RuntimeError("Must have a tile or nodegroup")
@@ -105,7 +108,6 @@ class SemanticTile(dict):
     def get_tile(self):
         self.__tile.data = self
         return self.__tile
-
 
 
 class TranslationMixin:
@@ -134,9 +136,7 @@ class TranslationMixin:
                         nodegroup = cls._nodegroup_objects()[node["nodegroupid"]]
                         node_obj = cls._node_objects()[nodeid]
                     else:
-                        nodegroup = NodeGroup(
-                            pk=node["nodegroupid"]
-                        )
+                        nodegroup = NodeGroup(pk=node["nodegroupid"])
                         node_obj = Node(
                             pk=nodeid,
                             nodeid=nodeid,
@@ -168,9 +168,7 @@ class TranslationMixin:
                         values = all_values
 
                     value = PseudoNode(
-                        node_obj,
-                        tile,
-                        related_prefetch=related_prefetch
+                        node_obj, tile, related_prefetch=related_prefetch
                     )
                     if multiple_values:
                         values[key] = PseudoNodeList(nodegroup)

--- a/arches_orm/_internals/view_models.py
+++ b/arches_orm/_internals/view_models.py
@@ -1,14 +1,50 @@
-from typing import Union
+from typing import Union, Any
 import uuid
-from functools import lru_cache
+from functools import cached_property, lru_cache
 from django.contrib.auth.models import User
-from arches.app.models.models import Node
-from arches.app.datatypes.datatypes import StringDataType
-from arches.app.datatypes.concept_types import ConceptDataType
+from arches.app.models.models import Node, ResourceInstance
+from arches.app.datatypes.datatypes import ResourceInstanceDataType, ResourceInstanceListDataType, StringDataType
+from arches.app.datatypes.concept_types import ConceptDataType, BaseConceptDataType, ConceptListDataType
 from arches.app.datatypes.base import BaseDataType
 from arches.app.models.tile import Tile
+from arches.app.models.resource import Resource
+from collections import UserDict, UserList
+from collections.abc import Iterable
+from .relations import WKRI
 
 
+class ViewModelFactory(UserDict):
+    @cached_property
+    def _datatype_factory(self):
+        """Caching datatype factory retrieval (possibly unnecessary)."""
+        from arches.app.datatypes.datatypes import DataTypeFactory
+        return DataTypeFactory()
+
+    def make(self, tile: Tile, node: Node, value: Any=None, parent: Any=None, related_prefetch=None):
+        datatype = self._datatype_factory.get_instance(node.datatype)
+        if node.datatype in self:
+            if node.datatype.startswith("resource-instance"):
+                return self[node.datatype].from_triple(tile, node, value, parent, datatype, related_prefetch)
+            else:
+                return self[node.datatype].from_triple(tile, node, value, parent, datatype)
+        else:
+            return datatype.transform_value_for_tile(
+                value or tile.data, **node.get("config", {})
+            )
+
+    def __call__(self, typ):
+        def wrapper(fn):
+            self[typ] = fn
+            return fn
+        return wrapper
+
+
+REGISTER = ViewModelFactory()
+
+def get_view_model_for_datatype(tile, node, parent, value=None, related_prefetch=None):
+    return REGISTER.make(tile, node, value=value, parent=parent, related_prefetch=related_prefetch)
+
+@REGISTER("user")
 class UserViewModel(str):
     """Wraps a user, so that a Django User can be obtained.
 
@@ -16,26 +52,44 @@ class UserViewModel(str):
     """
 
     _tile: Tile
-    _nodeid: uuid.UUID
+    _node: Node
     _user_datatype: BaseDataType
 
-    def __new__(cls, tile, node, user_datatype):
+    def __eq__(self, other):
+        return self.user == other.user
+
+    @classmethod
+    def from_triple(cls, tile, node, value, parent, user_datatype):
+        return cls(tile, node, value, user_datatype)
+
+    def __new__(cls, tile, node, value: User | int | None, user_datatype):
+        if value:
+            if isinstance(value, User):
+                tile.data[str(node.nodeid)] = value.pk
+            else:
+                tile.data[str(node.nodeid)] = value
+                display_value = value
+
         display_value = user_datatype.get_display_value(
             tile,
-            Node(nodeid=node.nodeid),
+            node,
         )
         mystr = super(UserViewModel, cls).__new__(cls, display_value)
         cls._tile = tile
-        cls._nodeid = node.nodeid
+        cls._node = node
         cls._user_datatype = user_datatype
         return mystr
 
     @property
     def user(self):
-        user = User.objects.get(pk=int(self._tile.data[str(self._nodeid)]))
+        user = User.objects.get(pk=int(self._tile.data[str(self._node.nodeid)]))
         return user
 
+    def as_tile_data(self):
+        return self.user.pk
 
+
+@REGISTER("string")
 class StringViewModel(str):
     """Wraps a string, allowing language translation.
 
@@ -43,25 +97,49 @@ class StringViewModel(str):
     """
 
     _tile: Tile
-    _nodeid: uuid.UUID
+    _node: Node
     _string_datatype: StringDataType
 
-    def __new__(cls, tile, node, string_datatype, language=None):
+    @classmethod
+    def from_triple(cls, tile, node, value: dict | None, parent, datatype):
+        return cls(tile, node, value, datatype)
+
+    def __new__(cls, tile, node, value: dict | str | None, string_datatype, language=None):
+        if value is not None:
+            tile.data.setdefault(str(node.nodeid), {})
+            if isinstance(value, dict):
+                tile.data[str(node.nodeid)].update(value)
+            else:
+                tile.data[str(node.nodeid)] = string_datatype.transform_value_for_tile(value)
         display_value = string_datatype.get_display_value(
-            tile, Node(nodeid=node.nodeid), language=language
+            tile, node, language=language
         )
         mystr = super(StringViewModel, cls).__new__(cls, display_value)
-        cls._tile = tile
-        cls._nodeid = node.nodeid
-        cls._string_datatype = string_datatype
+        mystr._tile = tile
+        mystr._node = node
+        mystr._string_datatype = string_datatype
         return mystr
 
     def lang(self, language):
         return self._string_datatype.get_display_value(
-            self._tile, Node(nodeid=self._nodeid), language=language
+            self._tile, self._node, language=language
         )
 
+    def as_tile_data(self):
+        changed = self._string_datatype.transform_value_for_tile(str(self))
 
+        # We do not want to lose all languages, because we only display one per string,
+        # but if there is a change, then all languages should go (until we have a multilingual
+        # version of the view model)
+        if self._tile.data and str(self._node.nodeid) in self._tile.data:
+            for key, val in changed.items():
+                if self._tile.data[str(self._node.nodeid)].get(key) != val:
+                    return changed
+            return self._tile.data[str(self._node.nodeid)]
+        return changed
+
+
+@REGISTER("concept")
 class ConceptValueViewModel(str):
     """Wraps a concept, allowing interrogation.
 
@@ -73,7 +151,16 @@ class ConceptValueViewModel(str):
     _concept_value_id: uuid.UUID
     _concept_datatype: ConceptDataType
 
-    def __new__(cls, concept_value_id: Union[str, uuid.UUID], concept_datatype):
+    @classmethod
+    def from_triple(cls, tile, node, value: uuid.UUID | str | None, parent, datatype):
+        if value is not None:
+            tile.data = value
+        return cls(tile.data, datatype)
+
+    def __eq__(self, other):
+        return self.conceptid == other.conceptid
+
+    def __new__(cls, concept_value_id: Union[str, uuid.UUID], concept_datatype: BaseConceptDataType):
         _concept_value_id: uuid.UUID = (
             concept_value_id
             if isinstance(concept_value_id, uuid.UUID)
@@ -114,3 +201,177 @@ class ConceptValueViewModel(str):
 
     def __repr__(self):
         return f"{self.value.concept_id}>{self._concept_value_id}[{self.text}]"
+
+    def as_tile_data(self):
+        return str(self._concept_value_id)
+
+
+@REGISTER("concept-list")
+class ConceptListValueViewModel(UserList):
+    """Wraps a concept list, allowing interrogation.
+
+    Subclasses list, so its members can be handled like a string enum, but keeps
+    the `.value`, `.lang` and `.text` properties cached, so you can
+    find out more.
+    """
+
+    _tile: Tile
+    _node: Node
+    _concept_list_datatype: BaseDataType
+
+    @classmethod
+    def from_triple(cls, tile, node, value: list[uuid.UUID | str] | None, parent, datatype):
+        if value is not None:
+            tile.data = value
+        return cls(tile.data, datatype, tile, node)
+
+    def __init__(self, concept_value_ids: Iterable[str | uuid.UUID], concept_list_datatype: ConceptListDataType, tile, node):
+        self._concept_list_datatype = concept_list_datatype
+        for concept_value_id in concept_value_ids:
+            self.append(concept_value_id)
+        self._tile = tile
+        self._node = node
+
+    def append(self, value):
+        if not isinstance(value, ConceptValueViewModel):
+            value = REGISTER.make(
+                self._tile,
+                self._node,
+                value=value
+            )
+        super().append(value)
+
+    def remove(self, value):
+        if not isinstance(value, ConceptValueViewModel):
+            value = REGISTER.make(
+                self._tile,
+                self._node,
+                value=value
+            )
+        super().remove(value)
+
+    def as_tile_data(self):
+        return [x.as_tile_data() for x in self]
+
+class RelatedResourceInstanceViewModel(WKRI):
+    """Wraps a concept, allowing interrogation.
+
+    Subclasses str, so it can be handled like a string enum, but keeps
+    the `.value`, `.lang` and `.text` properties cached, so you can
+    find out more.
+    """
+
+    @classmethod
+    def from_triple(cls, tile, node, value: uuid.UUID | str | WKRI | Resource | ResourceInstance | None, parent, datatype, related_prefetch):
+        if value is None:
+            raise NotImplementedError()
+        resource_instance_id = None
+        resource_instance = None
+        if isinstance(value, uuid.UUID | str):
+            resource_instance_id = value
+        else:
+            resource_instance = value
+        related = cls.create_related(parent, resource_instance, resource_instance_id, datatype, related_prefetch, tile, node)
+        return related
+
+    def as_tile_data(self):
+        raise NotImplementedError()
+
+    @classmethod
+    def create_related(cls, parent_wkri: WKRI, resource_instance: WKRI | Resource | ResourceInstance | None, resource_instance_id: uuid.UUID | str | None, resource_instance_datatype: ResourceInstanceDataType, related_prefetch, tile, node):
+        from .utils import get_well_known_resource_model_by_graph_id, attempt_well_known_resource_model
+        _resource_instance: WKRI | None = None
+
+        if not resource_instance:
+            if resource_instance_id:
+                _resource_instance = attempt_well_known_resource_model(
+                    resource_instance_id,
+                    related_prefetch=related_prefetch
+                )
+            else:
+                raise RuntimeError("Must pass a resource instance or ID")
+
+        if not isinstance(resource_instance, WKRI):
+            wkrm = get_well_known_resource_model_by_graph_id(resource_instance.graph_id, default=None)
+            if wkrm:
+                _resource_instance = wkrm.from_resource(resource_instance)
+            else:
+                raise RuntimeError("Cannot adapt unknown resource model")
+        else:
+            _resource_instance = resource_instance
+
+        if _resource_instance is None:
+            raise RuntimeError("Could not normalize resource instance")
+
+        datum = {}
+        datum["wkriFrom"] = parent_wkri
+        datum["wkriFromKey"] = node.alias # FIXME: we should use the ORM key to be consistent
+        datum["wkriFromNodeid"] = node.nodeid
+        datum["wkriFromTile"] = tile
+        datum["datatype"] = resource_instance_datatype
+
+        if _resource_instance._cross_record and _resource_instance._cross_record != datum:
+            raise NotImplementedError("Cannot currently reparent a resource instance")
+
+        _resource_instance._cross_record = datum
+
+        return _resource_instance
+
+
+    def get_relationships(self):
+        # TODO: nesting
+        return [self]
+
+class RelatedResourceInstanceListViewModel(UserList):
+    """Wraps a concept list, allowing interrogation.
+
+    Subclasses list, so its members can be handled like a string enum, but keeps
+    the `.value`, `.lang` and `.text` properties cached, so you can
+    find out more.
+    """
+
+    _tile: Tile
+    _node: Node
+    _resource_instance_list_datatype: BaseDataType
+
+    def __init__(self, parent_wkri, resource_instance_list, resource_instance_list_datatype: ResourceInstanceListDataType, tile, node, related_prefetch):
+        self._parent_wkri = parent_wkri
+        self._resource_instance_list_datatype = resource_instance_list_datatype
+        self._tile = tile
+        self._node = node
+        self._related_prefetch = related_prefetch
+        for resource_instance in resource_instance_list:
+            self.append(resource_instance)
+
+    def append(self, item: str | uuid.UUID | Resource | ResourceInstance | WKRI):
+        """Add a well-known resource to the list."""
+
+        if isinstance(item, RelatedResourceInstanceViewModel):
+            raise NotImplementedError("Cannot currently reparent related resources")
+
+        resource_instance = item if isinstance(item, Resource | ResourceInstance | WKRI) else None
+        resource_instance_id = item if isinstance(item, str | uuid.UUID) else None
+
+        value = REGISTER.make(
+            self._tile,
+            self._node,
+            value=(resource_instance or resource_instance_id),
+            parent=self._parent_wkri,
+            related_prefetch=self._related_prefetch
+        )
+        if str(value._cross_record["wkriFrom"]) != str(self._parent_wkri.id):
+            raise NotImplementedError("Cannot current reparent related resources")
+
+        return super().append(item)
+
+    def remove(self, value):
+        for item in self:
+            if value.resourceinstanceid == item.resourceinstanceid:
+                value = item
+        super().remove(value)
+
+    def get_relationships(self):
+        return sum((x.get_relationships() for x in self), [])
+
+    def as_tile_data(self):
+        return [x.as_tile_data() for x in self]

--- a/arches_orm/_internals/view_models.py
+++ b/arches_orm/_internals/view_models.py
@@ -3,8 +3,16 @@ import uuid
 from functools import cached_property, lru_cache
 from django.contrib.auth.models import User
 from arches.app.models.models import Node, ResourceInstance
-from arches.app.datatypes.datatypes import ResourceInstanceDataType, ResourceInstanceListDataType, StringDataType
-from arches.app.datatypes.concept_types import ConceptDataType, BaseConceptDataType, ConceptListDataType
+from arches.app.datatypes.datatypes import (
+    ResourceInstanceDataType,
+    ResourceInstanceListDataType,
+    StringDataType,
+)
+from arches.app.datatypes.concept_types import (
+    ConceptDataType,
+    BaseConceptDataType,
+    ConceptListDataType,
+)
 from arches.app.datatypes.base import BaseDataType
 from arches.app.models.tile import Tile
 from arches.app.models.resource import Resource
@@ -18,15 +26,27 @@ class ViewModelFactory(UserDict):
     def _datatype_factory(self):
         """Caching datatype factory retrieval (possibly unnecessary)."""
         from arches.app.datatypes.datatypes import DataTypeFactory
+
         return DataTypeFactory()
 
-    def make(self, tile: Tile, node: Node, value: Any=None, parent: Any=None, related_prefetch=None):
+    def make(
+        self,
+        tile: Tile,
+        node: Node,
+        value: Any = None,
+        parent: Any = None,
+        related_prefetch=None,
+    ):
         datatype = self._datatype_factory.get_instance(node.datatype)
         if node.datatype in self:
             if node.datatype.startswith("resource-instance"):
-                return self[node.datatype].from_triple(tile, node, value, parent, datatype, related_prefetch)
+                return self[node.datatype].from_triple(
+                    tile, node, value, parent, datatype, related_prefetch
+                )
             else:
-                return self[node.datatype].from_triple(tile, node, value, parent, datatype)
+                return self[node.datatype].from_triple(
+                    tile, node, value, parent, datatype
+                )
         else:
             return datatype.transform_value_for_tile(
                 value or tile.data, **node.get("config", {})
@@ -36,13 +56,18 @@ class ViewModelFactory(UserDict):
         def wrapper(fn):
             self[typ] = fn
             return fn
+
         return wrapper
 
 
 REGISTER = ViewModelFactory()
 
+
 def get_view_model_for_datatype(tile, node, parent, value=None, related_prefetch=None):
-    return REGISTER.make(tile, node, value=value, parent=parent, related_prefetch=related_prefetch)
+    return REGISTER.make(
+        tile, node, value=value, parent=parent, related_prefetch=related_prefetch
+    )
+
 
 @REGISTER("user")
 class UserViewModel(str):
@@ -104,16 +129,18 @@ class StringViewModel(str):
     def from_triple(cls, tile, node, value: dict | None, parent, datatype):
         return cls(tile, node, value, datatype)
 
-    def __new__(cls, tile, node, value: dict | str | None, string_datatype, language=None):
+    def __new__(
+        cls, tile, node, value: dict | str | None, string_datatype, language=None
+    ):
         if value is not None:
             tile.data.setdefault(str(node.nodeid), {})
             if isinstance(value, dict):
                 tile.data[str(node.nodeid)].update(value)
             else:
-                tile.data[str(node.nodeid)] = string_datatype.transform_value_for_tile(value)
-        display_value = string_datatype.get_display_value(
-            tile, node, language=language
-        )
+                tile.data[str(node.nodeid)] = string_datatype.transform_value_for_tile(
+                    value
+                )
+        display_value = string_datatype.get_display_value(tile, node, language=language)
         mystr = super(StringViewModel, cls).__new__(cls, display_value)
         mystr._tile = tile
         mystr._node = node
@@ -129,8 +156,8 @@ class StringViewModel(str):
         changed = self._string_datatype.transform_value_for_tile(str(self))
 
         # We do not want to lose all languages, because we only display one per string,
-        # but if there is a change, then all languages should go (until we have a multilingual
-        # version of the view model)
+        # but if there is a change, then all languages should go (until we have a
+        # multilingual version of the view model)
         if self._tile.data and str(self._node.nodeid) in self._tile.data:
             for key, val in changed.items():
                 if self._tile.data[str(self._node.nodeid)].get(key) != val:
@@ -160,7 +187,11 @@ class ConceptValueViewModel(str):
     def __eq__(self, other):
         return self.conceptid == other.conceptid
 
-    def __new__(cls, concept_value_id: Union[str, uuid.UUID], concept_datatype: BaseConceptDataType):
+    def __new__(
+        cls,
+        concept_value_id: Union[str, uuid.UUID],
+        concept_datatype: BaseConceptDataType,
+    ):
         _concept_value_id: uuid.UUID = (
             concept_value_id
             if isinstance(concept_value_id, uuid.UUID)
@@ -220,12 +251,20 @@ class ConceptListValueViewModel(UserList):
     _concept_list_datatype: BaseDataType
 
     @classmethod
-    def from_triple(cls, tile, node, value: list[uuid.UUID | str] | None, parent, datatype):
+    def from_triple(
+        cls, tile, node, value: list[uuid.UUID | str] | None, parent, datatype
+    ):
         if value is not None:
             tile.data = value
         return cls(tile.data, datatype, tile, node)
 
-    def __init__(self, concept_value_ids: Iterable[str | uuid.UUID], concept_list_datatype: ConceptListDataType, tile, node):
+    def __init__(
+        self,
+        concept_value_ids: Iterable[str | uuid.UUID],
+        concept_list_datatype: ConceptListDataType,
+        tile,
+        node,
+    ):
         self._concept_list_datatype = concept_list_datatype
         for concept_value_id in concept_value_ids:
             self.append(concept_value_id)
@@ -234,24 +273,17 @@ class ConceptListValueViewModel(UserList):
 
     def append(self, value):
         if not isinstance(value, ConceptValueViewModel):
-            value = REGISTER.make(
-                self._tile,
-                self._node,
-                value=value
-            )
+            value = REGISTER.make(self._tile, self._node, value=value)
         super().append(value)
 
     def remove(self, value):
         if not isinstance(value, ConceptValueViewModel):
-            value = REGISTER.make(
-                self._tile,
-                self._node,
-                value=value
-            )
+            value = REGISTER.make(self._tile, self._node, value=value)
         super().remove(value)
 
     def as_tile_data(self):
         return [x.as_tile_data() for x in self]
+
 
 class RelatedResourceInstanceViewModel(WKRI):
     """Wraps a concept, allowing interrogation.
@@ -262,7 +294,15 @@ class RelatedResourceInstanceViewModel(WKRI):
     """
 
     @classmethod
-    def from_triple(cls, tile, node, value: uuid.UUID | str | WKRI | Resource | ResourceInstance | None, parent, datatype, related_prefetch):
+    def from_triple(
+        cls,
+        tile,
+        node,
+        value: uuid.UUID | str | WKRI | Resource | ResourceInstance | None,
+        parent,
+        datatype,
+        related_prefetch,
+    ):
         if value is None:
             raise NotImplementedError()
         resource_instance_id = None
@@ -271,28 +311,50 @@ class RelatedResourceInstanceViewModel(WKRI):
             resource_instance_id = value
         else:
             resource_instance = value
-        related = cls.create_related(parent, resource_instance, resource_instance_id, datatype, related_prefetch, tile, node)
+        related = cls.create_related(
+            parent,
+            resource_instance,
+            resource_instance_id,
+            datatype,
+            related_prefetch,
+            tile,
+            node,
+        )
         return related
 
     def as_tile_data(self):
         raise NotImplementedError()
 
     @classmethod
-    def create_related(cls, parent_wkri: WKRI, resource_instance: WKRI | Resource | ResourceInstance | None, resource_instance_id: uuid.UUID | str | None, resource_instance_datatype: ResourceInstanceDataType, related_prefetch, tile, node):
-        from .utils import get_well_known_resource_model_by_graph_id, attempt_well_known_resource_model
+    def create_related(
+        cls,
+        parent_wkri: WKRI,
+        resource_instance: WKRI | Resource | ResourceInstance | None,
+        resource_instance_id: uuid.UUID | str | None,
+        resource_instance_datatype: ResourceInstanceDataType,
+        related_prefetch,
+        tile,
+        node,
+    ):
+        from .utils import (
+            get_well_known_resource_model_by_graph_id,
+            attempt_well_known_resource_model,
+        )
+
         _resource_instance: WKRI | None = None
 
         if not resource_instance:
             if resource_instance_id:
                 _resource_instance = attempt_well_known_resource_model(
-                    resource_instance_id,
-                    related_prefetch=related_prefetch
+                    resource_instance_id, related_prefetch=related_prefetch
                 )
             else:
                 raise RuntimeError("Must pass a resource instance or ID")
 
         if not isinstance(resource_instance, WKRI):
-            wkrm = get_well_known_resource_model_by_graph_id(resource_instance.graph_id, default=None)
+            wkrm = get_well_known_resource_model_by_graph_id(
+                resource_instance.graph_id, default=None
+            )
             if wkrm:
                 _resource_instance = wkrm.from_resource(resource_instance)
             else:
@@ -305,22 +367,27 @@ class RelatedResourceInstanceViewModel(WKRI):
 
         datum = {}
         datum["wkriFrom"] = parent_wkri
-        datum["wkriFromKey"] = node.alias # FIXME: we should use the ORM key to be consistent
+        datum[
+            "wkriFromKey"
+        ] = node.alias  # FIXME: we should use the ORM key to be consistent
         datum["wkriFromNodeid"] = node.nodeid
         datum["wkriFromTile"] = tile
         datum["datatype"] = resource_instance_datatype
 
-        if _resource_instance._cross_record and _resource_instance._cross_record != datum:
+        if (
+            _resource_instance._cross_record
+            and _resource_instance._cross_record != datum
+        ):
             raise NotImplementedError("Cannot currently reparent a resource instance")
 
         _resource_instance._cross_record = datum
 
         return _resource_instance
 
-
     def get_relationships(self):
         # TODO: nesting
         return [self]
+
 
 class RelatedResourceInstanceListViewModel(UserList):
     """Wraps a concept list, allowing interrogation.
@@ -334,7 +401,15 @@ class RelatedResourceInstanceListViewModel(UserList):
     _node: Node
     _resource_instance_list_datatype: BaseDataType
 
-    def __init__(self, parent_wkri, resource_instance_list, resource_instance_list_datatype: ResourceInstanceListDataType, tile, node, related_prefetch):
+    def __init__(
+        self,
+        parent_wkri,
+        resource_instance_list,
+        resource_instance_list_datatype: ResourceInstanceListDataType,
+        tile,
+        node,
+        related_prefetch,
+    ):
         self._parent_wkri = parent_wkri
         self._resource_instance_list_datatype = resource_instance_list_datatype
         self._tile = tile
@@ -349,7 +424,9 @@ class RelatedResourceInstanceListViewModel(UserList):
         if isinstance(item, RelatedResourceInstanceViewModel):
             raise NotImplementedError("Cannot currently reparent related resources")
 
-        resource_instance = item if isinstance(item, Resource | ResourceInstance | WKRI) else None
+        resource_instance = (
+            item if isinstance(item, Resource | ResourceInstance | WKRI) else None
+        )
         resource_instance_id = item if isinstance(item, str | uuid.UUID) else None
 
         value = REGISTER.make(
@@ -357,7 +434,7 @@ class RelatedResourceInstanceListViewModel(UserList):
             self._node,
             value=(resource_instance or resource_instance_id),
             parent=self._parent_wkri,
-            related_prefetch=self._related_prefetch
+            related_prefetch=self._related_prefetch,
         )
         if str(value._cross_record["wkriFrom"]) != str(self._parent_wkri.id):
             raise NotImplementedError("Cannot current reparent related resources")

--- a/arches_orm/_internals/wrapper.py
+++ b/arches_orm/_internals/wrapper.py
@@ -5,7 +5,13 @@ from django.dispatch import Signal
 from arches.app.models.models import ResourceXResource, Node, NodeGroup
 from arches.app.models.tile import Tile as TileProxyModel
 from arches.app.models.system_settings import settings as system_settings
-from .translation import PseudoNode, PseudoNodeList, TranslationMixin, LOAD_ALL_NODES, LOAD_FULL_NODE_OBJECTS
+from .translation import (
+    PseudoNode,
+    PseudoNodeList,
+    TranslationMixin,
+    LOAD_ALL_NODES,
+    LOAD_FULL_NODE_OBJECTS,
+)
 from .relations import RelationList
 
 logger = logging.getLogger(__name__)
@@ -69,11 +75,7 @@ class ResourceModelWrapper(TranslationMixin):
                     raise NotImplementedError("Cannot replace a full pseudo-node list")
                 self._values[key] = PseudoNodeList(nodegroup)
                 self._values[key] += [
-                    PseudoNode(
-                        tile=None,
-                        node=node_obj,
-                        value=item
-                    ) for item in value
+                    PseudoNode(tile=None, node=node_obj, value=item) for item in value
                 ]
             else:
                 self._values.setdefault(key, PseudoNode(tile=None, node=node_obj))
@@ -218,12 +220,7 @@ class ResourceModelWrapper(TranslationMixin):
             node_obj = self._node_objects()[self._nodes[key]["nodeid"]]
             if self._nodes[key]["datatype"][2]:
                 kwargs[key] = PseudoNodeList(nodegroup)
-                kwargs[key] += [
-                    PseudoNode(
-                        node=node_obj,
-                        value=item
-                    ) for item in value
-                ]
+                kwargs[key] += [PseudoNode(node=node_obj, value=item) for item in value]
             else:
                 kwargs[key] = PseudoNode(node=node_obj)
                 kwargs[key].value = value

--- a/arches_orm/_internals/wrapper.py
+++ b/arches_orm/_internals/wrapper.py
@@ -5,7 +5,7 @@ from django.dispatch import Signal
 from arches.app.models.models import ResourceXResource, Node, NodeGroup
 from arches.app.models.tile import Tile as TileProxyModel
 from arches.app.models.system_settings import settings as system_settings
-from .translation import TranslationMixin, LOAD_ALL_NODES, LOAD_FULL_NODE_OBJECTS
+from .translation import PseudoNode, PseudoNodeList, TranslationMixin, LOAD_ALL_NODES, LOAD_FULL_NODE_OBJECTS
 from .relations import RelationList
 
 logger = logging.getLogger(__name__)
@@ -62,12 +62,22 @@ class ResourceModelWrapper(TranslationMixin):
         else:
             if self._lazy and not self._filled:
                 self.fill_from_resource(self._related_prefetch)
+            nodegroup = self._nodegroup_objects()[self._nodes[key]["nodegroupid"]]
+            node_obj = self._node_objects()[self._nodes[key]["nodeid"]]
             if self._nodes[key]["datatype"][2]:
-                self._values.setdefault(key, [])
-                self._values[key] += [{"tile": None, "value": item} for item in value]
+                if self._values.get(key):
+                    raise NotImplementedError("Cannot replace a full pseudo-node list")
+                self._values[key] = PseudoNodeList(nodegroup)
+                self._values[key] += [
+                    PseudoNode(
+                        tile=None,
+                        node=node_obj,
+                        value=item
+                    ) for item in value
+                ]
             else:
-                self._values.setdefault(key, {"tile": None, "value": value})
-                self._values[key]["value"] = value
+                self._values.setdefault(key, PseudoNode(tile=None, node=node_obj))
+                self._values[key].value = value
 
     def __getattr__(self, key):
         """Retrieve Python values for nodes attributes."""
@@ -77,9 +87,9 @@ class ResourceModelWrapper(TranslationMixin):
             if isinstance(value, RelationList):
                 return value
             if self._nodes[key]["datatype"][2]:
-                return (item["value"] for item in value)
+                return (item.value for item in value)
             else:
-                return value["value"]
+                return value.value
         elif key in self._nodes:
             if self._lazy and not self._filled:
                 self.fill_from_resource(self._related_prefetch)
@@ -204,23 +214,19 @@ class ResourceModelWrapper(TranslationMixin):
             )
 
         for key, value in kwargs.items():
-            if isinstance(value, list) and any(
-                types := [isinstance(entry, ResourceModelWrapper) for entry in value]
-            ):
-                if not all(types):
-                    raise NotImplementedError(
-                        "Cannot currently handle mixed"
-                        " ResourceModelWrapper/non-ResourceModelWrapper"
-                        " lists"
-                    )
-                kwargs[key] = RelationList(self, key, self._nodes[key]["nodeid"], None)
-                for resource in value:
-                    kwargs[key].append(resource)
+            nodegroup = self._nodegroup_objects()[self._nodes[key]["nodegroupid"]]
+            node_obj = self._node_objects()[self._nodes[key]["nodeid"]]
+            if self._nodes[key]["datatype"][2]:
+                kwargs[key] = PseudoNodeList(nodegroup)
+                kwargs[key] += [
+                    PseudoNode(
+                        node=node_obj,
+                        value=item
+                    ) for item in value
+                ]
             else:
-                if self._nodes[key]["datatype"][2]:
-                    kwargs[key] = [{"tile": None, "value": item} for item in value]
-                else:
-                    kwargs[key]["value"] = value
+                kwargs[key] = PseudoNode(node=node_obj)
+                kwargs[key].value = value
 
         self._values.update(kwargs)
 
@@ -405,14 +411,14 @@ class ResourceModelWrapper(TranslationMixin):
             if isinstance(value, list) or isinstance(value, RelationList):
                 if value:
                     if not isinstance(value, RelationList):
-                        value = [item["value"] for item in value]
+                        value = [item.value for item in value]
                     table.append([key, value[0].__class__.__name__, str(value[0])])
                     for val in value[1:]:
                         table.append(["", val.__class__.__name__, str(val)])
                 else:
                     table.append([key, "", "(empty)"])
             else:
-                table.append([key, value["value"].__class__.__name__, str(value)])
+                table.append([key, value.value.__class__.__name__, str(value)])
         return description + tabulate(table)
 
     @classmethod


### PR DESCRIPTION
This starts a move away from big walking functions and plain Python dicts, to PseudoNodes that can behave as a user might expect in Python code.

Unfortunately, this does embed the Tile and Node more heavily into the ORM, but the idea would be to make this swappable in the future, so the ORM could run client or serverside.