### PR TITLE
Do not hit db on import

### DIFF
--- a/arches_orm/graphql/django_asgi.py
+++ b/arches_orm/graphql/django_asgi.py
@@ -1,11 +1,10 @@
 import os
-from asgiref.sync import sync_to_async
 import django
 if "DJANGO_SETTINGS_MODULE" not in os.environ:
     raise RuntimeError("DJANGO_SETTINGS_MODULE must be explicitly set")
 
 django.setup()
-from arches_orm.graphql import _asgi
+from arches_orm.graphql import _asgi # noqa: E402
 
 async def app(scope, receive, send):
     await _asgi.app(scope, receive, send)

--- a/arches_orm/wrapper.py
+++ b/arches_orm/wrapper.py
@@ -76,7 +76,9 @@ class ResourceWrapper(ABC):
                     real_key = self._model_remapping[key].replace("*", ".")
                     if "." in real_key:
                         to_get, to_set = real_key.split(".", -1)
-                    got = self._get_remap(to_get)
+                        got = self._get_remap(to_get)
+                    else:
+                        got = self.get_root()
                     if isinstance(got, UserList):
                         if len(got) == 0:
                             got = got.append()


### PR DESCRIPTION
### What does this PR do?

Removes any calls to the DB, specifically `ResourceWrapper._build_nodes` in `ResourceWrapper.__init_subclass__` and ensures it gets called only behind class-level caches on-demand.

### How to test?

A complete Arches database build (with no pre-existing database) should be successful even if module level `arches_orm.model` imports are seen before the DB exists. Note that _using_ the imports is still logically impossible, as they are database-defined.

### Who can test?

@philtweir as a bug-fix that will be fully confirmed downstream.