### PR TITLE
Only warn if Django group or user missing

### DIFF
--- a/arches_orm/arches_django/datatypes/django_group.py
+++ b/arches_orm/arches_django/datatypes/django_group.py
@@ -1,3 +1,4 @@
+import logging
 from django.contrib.auth.models import Group
 
 from arches_orm.view_models import (
@@ -5,6 +6,8 @@ from arches_orm.view_models import (
     GroupProtocol,
 )
 from ._register import REGISTER
+
+logger = logging.getLogger(__name__)
 
 
 class DjangoGroupViewModel(Group, GroupViewModelMixin):
@@ -30,7 +33,10 @@ def django_group(tile, node, value, _, __, ___, group) -> GroupProtocol:
                 group = DjangoGroupViewModel()
                 group.__dict__.update(value.__dict__)
         if value:
-            group = DjangoGroupViewModel.objects.get(pk=int(value))
+            try:
+                group = DjangoGroupViewModel.objects.get(pk=int(value))
+            except DjangoGroupViewModel.DoesNotExist:
+                logger.warning("Django Group is missing for pk value %s", str(value))
     if not group:
         group = DjangoGroupViewModel()
     return group

--- a/arches_orm/arches_django/datatypes/user.py
+++ b/arches_orm/arches_django/datatypes/user.py
@@ -1,3 +1,4 @@
+import logging
 from django.contrib.auth.models import User
 
 from arches_orm.view_models import (
@@ -5,6 +6,8 @@ from arches_orm.view_models import (
     UserProtocol,
 )
 from ._register import REGISTER
+
+logger = logging.getLogger(__name__)
 
 
 class UserViewModel(User, UserViewModelMixin):
@@ -30,7 +33,10 @@ def user(tile, node, value, _, __, ___, user_datatype) -> UserProtocol:
                 user = UserViewModel()
                 user.__dict__.update(value.__dict__)
         if value:
-            user = UserViewModel.objects.get(pk=int(value))
+            try:
+                user = UserViewModel.objects.get(pk=int(value))
+            except UserViewModel.DoesNotExist:
+                logger.warning("User is missing for pk value %s", str(value))
     if not user:
         user = UserViewModel()
     return user


### PR DESCRIPTION
### What does this PR do?

Only warn if a Django group or user that is attached to a resource instance is missing. This can happen for several reasons, and a nicer way of handling this (perhaps, like EmptyConcept...) would be good.
